### PR TITLE
bug fix and reassembly adjustment 

### DIFF
--- a/includes/5p/common.hpp
+++ b/includes/5p/common.hpp
@@ -8,8 +8,8 @@ namespace common {
 
 // log levels
 enum class LogLevel {
-    DEBUG_LEVEL = 0,
-    ALSO_DEBUG_LEVEL = 1,
+    TRACE_LEVEL = 0,
+    DEBUG_LEVEL = 1,
     INFO_LEVEL = 2,
     WARNING_LEVEL = 3,
     ERROR_LEVEL = 4,

--- a/includes/5p/common.hpp
+++ b/includes/5p/common.hpp
@@ -3,6 +3,7 @@
 #define _SILENCE_STDEXT_ARR_ITERS_DEPRECATION_WARNING
 
 #include <iostream>
+#include <cstdint>
 
 namespace common {
 

--- a/includes/5p/pcapreader.hpp
+++ b/includes/5p/pcapreader.hpp
@@ -13,6 +13,7 @@
 #include <pcapplusplus/TcpLayer.h>
 #include <pcapplusplus/UdpLayer.h>
 #include <pcapplusplus/IPReassembly.h>
+#include <pcapplusplus/Logger.h>
 
 #include <boost/filesystem.hpp>
 #include <iostream>
@@ -36,7 +37,13 @@ class Reader {
     pcpp::IPReassembly ip_reassembly_;
 
     public:
-    Reader();
+
+    /*
+      * Constructor
+      * @param verboseLogging: if true, debug logging is added for pcapplusplus library
+       * @return void
+    */
+    explicit Reader(const bool verboseLogging = false);
     ~Reader();
 
     /*


### PR DESCRIPTION
- fix that fragmented packets received a timestamp and were handled as valid packets

- added warning if no packet is processed until program exit
- distinguish debug and trace log level
- for trace level pcap++ library debug logs
- extended readme with reassembly section